### PR TITLE
Secrets file handling fixes

### DIFF
--- a/gitlab/files/gitlab-secrets.yml
+++ b/gitlab/files/gitlab-secrets.yml
@@ -1,8 +1,9 @@
-
+---
 {%- for name, infos in salt['pillar.get']('gitlab:databases', {}).items() %}
-{% if 'key' in infos %}
+{%- if 'secrets' in infos %}
 {{ name }}:
-  db_key_base: {{ infos['key'] }}
-{% endif %}
-
+  {%- for key, value in infos['secrets'].items() %}
+  {{ key }}: {{ value|yaml_dquote }}
+  {%- endfor %}
+{%- endif %}
 {%- endfor %}

--- a/gitlab/files/gitlab-shell-config.yml
+++ b/gitlab/files/gitlab-shell-config.yml
@@ -34,7 +34,7 @@ auth_file: "{{ root_dir }}/.ssh/authorized_keys"
 
 # File that contains the secret key for verifying access to GitLab.
 # Default is .gitlab_shell_secret in the root directory.
-secret_file: "{{ salt['pillar.get']('gitlab:secret_file', '/opt/git/.gitlab_shell_secret') }}"
+secret_file: "{{ salt['pillar.get']('gitlab:shell:secret:path', '/opt/git/.gitlab_shell_secret') }}"
 
 # Redis settings used for pushing commit notices to gitlab
 redis:

--- a/gitlab/gitlab.sls
+++ b/gitlab/gitlab.sls
@@ -339,8 +339,8 @@ gitlab-service:
 
 gitlab-secret_file:
   file.managed:
-    - name: {{ salt['pillar.get']('gitlab:secret_file', '/opt/git/.gitlab_shell_secret') }}
+    - name: {{ salt['pillar.get']('gitlab:shell:secret:path', '/opt/git/.gitlab_shell_secret') }}
+    - contents_pillar: gitlab:shell:secret:value
     - user: git
     - group: git
     - mode: 640
-    - contents_pillar: gitlab:secret_key

--- a/pillar.example
+++ b/pillar.example
@@ -37,7 +37,10 @@ gitlab:
       name: gitlab
       pool: 10
       host: localhost
-      key: YOUR_KEY
+      secrets:
+        db_key_base:
+        secret_key_base:
+        otp_key_base:
     development:
       engine: postgresql
       name: gitlab

--- a/pillar.example
+++ b/pillar.example
@@ -31,8 +31,6 @@ gitlab:
   shell_version: v2.7.2
   gitlab_version: 8-7-stable
   workhorse_version: v0.7.1
-  secret_key: 0123456789abcdef0123456789abcde
-  secret_file: "/opt/git/.gitlab_shell_secret"
   databases:
     production: &production
       engine: postgresql
@@ -82,6 +80,9 @@ gitlab:
     #{% elif grains['os_family'] == 'Debian' %}
     #ca_path: /etc/ssl/certs
     #{% endif %}
+    secret:
+      value: 0123456789abcdef0123456789abcde
+      path: "/opt/git/.gitlab_shell_secret"
 
   unicorn:
     worker_processes: 2


### PR DESCRIPTION
The reason why we could not get OTP working after running highstates.
This change is also required for extra secrets that we haven't seen side effects with and newer secrets to be used in 9.0 release series.

I pondered using simple yaml serialization directly but this works for now.