### PR TITLE
Gitlab 9.3 support

### DIFF
--- a/gitlab/files/gitlab-default
+++ b/gitlab/files/gitlab-default
@@ -98,3 +98,5 @@ shell_path="/bin/bash"
 # This variable controls whether the init script starts/stops Gitaly
 gitaly_enabled=false
 gitaly_log="{{ logs_dir }}/gitaly.log"
+gitaly_pid_path="$pid_path/gitaly.pid"
+gitaly_log="{{ logs_dir }}/log/gitaly.log"

--- a/gitlab/files/gitlab-gitlab.yml
+++ b/gitlab/files/gitlab-gitlab.yml
@@ -185,7 +185,7 @@ production: &base
   ## Gravatar
   ## For Libravatar see: http://doc.gitlab.com/ce/customization/libravatar.html
   gravatar:
-    # gravatar urls: possible placeholders: %{hash} %{size} %{email}
+    # gravatar urls: possible placeholders: %{hash} %{size} %{email} %{username}
     # plain_url: "http://..."     # default: http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=identicon
     # ssl_url:   "https://..."    # default: https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=identicon
 
@@ -198,7 +198,7 @@ production: &base
       cron: "0 * * * *"
     # Execute scheduled triggers
     pipeline_schedule_worker:
-      cron: "0 */12 * * *"
+      cron: "19 * * * *"
     # Remove expired build artifacts
     expire_build_artifacts_worker:
       cron: "50 * * * *"
@@ -352,6 +352,10 @@ production: &base
     # Uncomment this to automatically sign in with a specific omniauth provider's without
     # showing GitLab's sign-in page (default: show the GitLab sign-in page)
     # auto_sign_in_with_provider: saml
+
+    # Sync user's email address from the specified Omniauth provider every time the user logs
+    # in (default: nil). And consequently make this field read-only.
+    # sync_email_from_provider: cas3
 
     # CAUTION!
     # This allows users to login without having a user account first. Define the allowed providers

--- a/gitlab/files/gitlab-gitlab.yml
+++ b/gitlab/files/gitlab-gitlab.yml
@@ -512,7 +512,7 @@ production: &base
 
     # File that contains the secret key for verifying access for gitlab-shell.
     # Default is '.gitlab_shell_secret' relative to Rails.root (i.e. root of the GitLab app).
-    secret_file: "{{ salt['pillar.get']('gitlab:secret_file', '/opt/git/.gitlab_shell_secret') }}"
+    secret_file: "{{ salt['pillar.get']('gitlab:secret_file', root_dir ~ '/.gitlab_shell_secret') }}"
 
     # Git over HTTP
     upload_pack: true

--- a/gitlab/gitlab-shell.sls
+++ b/gitlab/gitlab-shell.sls
@@ -63,6 +63,18 @@ gitlab-shell-config:
       - git: gitlab-shell-fetcher
     {% endif %}
 
+gitlab-shell-compile:
+  cmd.run:
+    - user: git
+    - cwd: {{ shell_dir_content }}
+    - name: ./bin/compile
+    - onchanges:
+    {% if salt['pillar.get']('gitlab:archives:enabled', false) %}
+      - archive: gitlab-shell-fetcher
+    {% else %}
+      - git: gitlab-shell-fetcher
+    {% endif %}
+
 gitlab-shell:
   cmd.wait:
     - user: git
@@ -77,6 +89,7 @@ gitlab-shell:
     {% endif %}
     - require:
       - file: gitlab-shell-config
+      - cmd: gitlab-shell-compile
 
 #gitlab-shell-chmod-bin:
 #  file.directory:


### PR DESCRIPTION
Smooth upgrade. Gitaly should be default on but I delayed that to 9.4 as it became mandatory in this release.